### PR TITLE
fix: :adhesive_bandage: Исправление ошибки при формировании имени ресурса

### DIFF
--- a/src/Commands/MoonShineRBACResourceCommand.php
+++ b/src/Commands/MoonShineRBACResourceCommand.php
@@ -30,9 +30,7 @@ class MoonShineRBACResourceCommand extends Command
 
         $arguments = [];
 
-        if ($this->argument('name')) {
-            $arguments['name'] = $this->argument('name');
-        }
+        $arguments['name'] = $this->argument('name') ?? $this->ask('Name of the resource');
 
         if ($this->option('model')) {
             $arguments['--model'] = $this->option('model');
@@ -44,7 +42,7 @@ class MoonShineRBACResourceCommand extends Command
 
         $this->call('moonshine:resource', $arguments);
 
-        $name = $this->argument('name');
+        $name = $arguments['name'];
 
         if (!str_contains($name, 'Resource')) {
             $name .= 'Resource';


### PR DESCRIPTION
Ранее, если в параметрах консольной команды `php artisan moonshine-rbac:resource` не указывалось имя ресурса, в таблицу 'permissions' базы данных записывались значения вида - 'Resource.viewAny' и т.п.

В связи с тем, что при выполнении дочерней команды невозможно получить доступ к введенным данным, реализовано получение имени ресурса, в случае если оно не было передано в аргументах текущей команды.
