### PR TITLE
fix: :adhesive_bandage: Разрешения для PermissionResource при install

### DIFF
--- a/src/Commands/MoonShineRBACInstallCommand.php
+++ b/src/Commands/MoonShineRBACInstallCommand.php
@@ -42,6 +42,10 @@ class MoonShineRBACInstallCommand extends Command
             'resourceName' => 'RoleResource'
         ]);
 
+        $this->call('moonshine-rbac:permissions', [
+            'resourceName' => 'PermissionResource'
+        ]);
+
         $this->createRole();
 
         info('MoonShine Roles-Permissions package installed successfully.');


### PR DESCRIPTION
Возникала ошибка при сохранении разрешений у роли в связи с отсутствием в базе разрешений для PermissionResource.