### PR TITLE
nullable_avatar

### DIFF
--- a/database/migrations/create_or_supplement_users_table.php
+++ b/database/migrations/create_or_supplement_users_table.php
@@ -27,7 +27,7 @@ return new class extends Migration {
                 $table->string('email')->unique();
                 $table->timestamp('email_verified_at')->nullable();
                 $table->string('password');
-                $table->string('avatar');
+                $table->string('avatar')->nullable();
 
                 $table->rememberToken();
                 $table->timestamps();


### PR DESCRIPTION
При выполнении консольной команды были проблемы с полем аватара, предлагаю сделать его не обязательным.
Притом что в миграции выше он не обязательный (если таблица users существует).
Так же на форме ресурса UserResource аватар не обязательный