### PR TITLE
fix: method getFiller does not exist in MenuGroup

### DIFF
--- a/src/Components/MenuRBAC.php
+++ b/src/Components/MenuRBAC.php
@@ -44,9 +44,13 @@ class MenuRBAC
             }
         }
 
+        if (!$item instanceof MenuItem) {
+            return;
+        }
+
         $resource = $item->getFiller();
 
-        if (!$item instanceof MenuItem || !$resource instanceof ModelResource) {
+        if (!$resource instanceof ModelResource) {
             return;
         }
 


### PR DESCRIPTION
При использовании MenuRBAC вылетала ошибка: 
```
Method MoonShine\MenuManager\MenuGroup::getFiller does not exist
```

Вынес проверку ```$item instanceof MenuItem``` перед вызовом данного метода