### PR TITLE
Фикс бага с синхронизацией кастомной роли

### DIFF
--- a/src/Http/Controllers/MoonShineRBACController.php
+++ b/src/Http/Controllers/MoonShineRBACController.php
@@ -24,8 +24,9 @@ class MoonShineRBACController extends MoonShineController
         $this->superAdminRoleId = config('moonshine.auth.model')::SUPER_ADMIN_ROLE_ID;
     }
 
-    public function attachPermissionsToRole(Request $request, Role $role)
+    public function attachPermissionsToRole(Request $request, $role)
     {
+        $role = config('permission.models.role')::findOrFail($role);
         if ($request->get('permissions') == null) {
             $role->syncPermissions([]);
 

--- a/src/Http/Controllers/MoonShineRBACController.php
+++ b/src/Http/Controllers/MoonShineRBACController.php
@@ -24,7 +24,7 @@ class MoonShineRBACController extends MoonShineController
         $this->superAdminRoleId = config('moonshine.auth.model')::SUPER_ADMIN_ROLE_ID;
     }
 
-    // TODO: Consider proper type-hinting or validation for $role parameter
+    // TODO: Consider proper type-hinting for $role parameter
     public function attachPermissionsToRole(Request $request, $role)
     {
         $role = config('permission.models.role')::findOrFail($role);

--- a/src/Http/Controllers/MoonShineRBACController.php
+++ b/src/Http/Controllers/MoonShineRBACController.php
@@ -24,6 +24,7 @@ class MoonShineRBACController extends MoonShineController
         $this->superAdminRoleId = config('moonshine.auth.model')::SUPER_ADMIN_ROLE_ID;
     }
 
+    // TODO: Consider proper type-hinting or validation for $role parameter
     public function attachPermissionsToRole(Request $request, $role)
     {
         $role = config('permission.models.role')::findOrFail($role);


### PR DESCRIPTION
Раньше если сменить роль в конфиге Spatie - ничего не менялось и роль все равно тянулась из Спати пакета на синхронизации, выдавало ошибку. Сейчас мы убрали route model binding и тянем из конфига модель, чтобы ее можно было менять. 

В идеале сделать отдельный класс и инжектить его из провайдера - но как временный фикс бага пойдет